### PR TITLE
Change ptr char/ALCchar types to cstring

### DIFF
--- a/src/openal.nim
+++ b/src/openal.nim
@@ -218,7 +218,7 @@ proc alDisable*(capability: ALenum)
 proc alIsEnabled*(capability: ALenum): bool
 
 # State retrieval
-proc alGetString*(param: ALenum): ptr char
+proc alGetString*(param: ALenum): cstring
 proc alGetBooleanv*(param: ALenum; data: ptr bool)
 proc alGetIntegerv*(param: ALenum; data: ptr ALint)
 proc alGetFloatv*(param: ALenum; data: ptr ALfloat)
@@ -235,9 +235,9 @@ proc alGetError*(): ALenum
 # Extension support.
 # Query for the presence of an extension, and obtain any appropriate
 # function pointers and enum values.
-proc alIsExtensionPresent*(extname: ptr char): bool
-proc alGetProcAddress*(fname: ptr char): pointer
-proc alGetEnumValue*(ename: ptr char): ALenum
+proc alIsExtensionPresent*(extname: cstring): bool
+proc alGetProcAddress*(fname: cstring): pointer
+proc alGetEnumValue*(ename: cstring): ALenum
 
 # LISTENER
 # Listener represents the location and orientation of the

--- a/src/openal/alc.nim
+++ b/src/openal/alc.nim
@@ -92,7 +92,7 @@ proc alcGetCurrentContext*(): ALCcontext
 proc alcGetContextsDevice*(context: ALCcontext): ALCdevice
 
 # Device Management
-proc alcOpenDevice*(devicename: ptr ALCchar): ALCdevice
+proc alcOpenDevice*(devicename: cstring): ALCdevice
 proc alcCloseDevice*(device: ALCdevice): bool
 
 # Error support.
@@ -103,16 +103,16 @@ proc alcGetError*(device: ALCdevice): ALCenum
 # Extension support.
 # Query for the presence of an extension, and obtain any appropriate
 # function pointers and enum values.
-proc alcIsExtensionPresent*(device: ALCdevice; extname: ptr ALCchar): bool
-proc alcGetProcAddress*(device: ALCdevice; funcname: ptr ALCchar): pointer
-proc alcGetEnumValue*(device: ALCdevice; enumname: ptr ALCchar): ALCenum
+proc alcIsExtensionPresent*(device: ALCdevice; extname: cstring): bool
+proc alcGetProcAddress*(device: ALCdevice; funcname: cstring): pointer
+proc alcGetEnumValue*(device: ALCdevice; enumname: cstring): ALCenum
 
 # Query functions
-proc alcGetString*(device: ALCdevice; param: ALCenum): ptr ALCchar
+proc alcGetString*(device: ALCdevice; param: ALCenum): cstring
 proc alcGetIntegerv*(device: ALCdevice; param: ALCenum; size: ALCsizei; data: ptr ALCint)
 
 # Capture functions
-proc alcCaptureOpenDevice*(devicename: ptr ALCchar; frequency: ALCuint; format: ALCenum; buffersize: ALCsizei): ALCdevice
+proc alcCaptureOpenDevice*(devicename: cstring; frequency: ALCuint; format: ALCenum; buffersize: ALCsizei): ALCdevice
 proc alcCaptureCloseDevice*(device: ALCdevice): bool
 proc alcCaptureStart*(device: ALCdevice)
 proc alcCaptureStop*(device: ALCdevice)


### PR DESCRIPTION
OpenAL has functions that take an string type argument.
If string type arguments are defined as `ptr char`, string literals need to be cast to `ptr char`.
This PR change `ptr char` and `ptr ALCchar` types to `cstring` so that string literals can be passed to functions without cast.